### PR TITLE
Added a possibility to use a bearer token in api-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# iot-platform-middleware-redux
+
+## Tests
+
+Create .env file in the project root with the following content:
+
+```
+API_BASE_URL=https://ddh-api.azure-api.net
+AUTH0_OAUTH_TOKEN_URL=https://denim-data-hub.eu.auth0.com/oauth/token
+AUTH0_CLIENT_ID=<Auth0 client ID>
+AUTH0_CLIENT_SECRET=<Auth0 client secret>
+AUTH0_AUDIENCE=https://ddh-api.azure-api.net
+```
+
+The referenced Auth0 client has to have the 'client_credentials' grant type enabled and have sufficient permissions to access the API endpoints.
+
+To run the tests, execute:
+
+```
+npm run test
+```

--- a/middleware.js
+++ b/middleware.js
@@ -1,12 +1,14 @@
 import { getDefaultMiddleware } from '@reduxjs/toolkit';
 export { default as devicesReducer, getAllDevices, getTwin, updateTwin } from './redux/features/devices.js';
+export { Auth0SessionProvider } from './redux/providers/auth0SessionProvider.js';
 
-export default function(settingsProvider, cacheProvider) {
+export default function(settingsProvider, cacheProvider, sessionProvider) {
     return getDefaultMiddleware({
         thunk: {
             extraArgument: {
                 settingsProvider,
-                cacheProvider
+                cacheProvider,
+                sessionProvider
             }
         }
     });

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.0",
     "chai": "^4.2.0",
+    "dotenv": "^8.2.0",
     "mocha": "^7.1.1",
     "redux-logger": "^3.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denim/iot-platform-middleware-redux",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "middleware.js",
   "scripts": {

--- a/redux/features/request.js
+++ b/redux/features/request.js
@@ -7,12 +7,17 @@ const makeKey = request => {
 
 const makeUrl = (settings, url) => `${settings.API_URL}${url}`;
 
-const createRequest = (method, url, subscriptionKey, query, data, options) => {
+const createRequest = (method, url, subscriptionKey, query, data, token, options) => {
     const request = superagent[method](url);
 
     // Set query parameters.
     if (query !== undefined) {
         request.query(query);
+    }
+
+    // Set token if given
+    if (token !== undefined) {
+        request.set('Authorization', `Bearer ${token}`);
     }
 
     // Set subscription key if given.
@@ -40,8 +45,9 @@ export const invokeRequest = createAsyncThunk(
         const { method, url } = options;
         const key = makeKey(options);
         const APIurl = makeUrl(thunk.extra.settingsProvider, url);
+        const token = thunk.extra.sessionProvider.getToken();
         try {
-            const response = await createRequest(method, APIurl, null, null, options.data);
+            const response = await createRequest(method, APIurl, null, null, options.data, token);
             const { body, error } = response;
             return { key, body, error };
         } catch (err) {

--- a/redux/providers/auth0SessionProvider.js
+++ b/redux/providers/auth0SessionProvider.js
@@ -1,0 +1,9 @@
+export class Auth0SessionProvider {
+    getToken() { 
+        return this.token 
+    }
+    
+    setToken(token) { 
+        this.token = token
+    }
+}

--- a/redux/utils.js
+++ b/redux/utils.js
@@ -1,4 +1,4 @@
-export default async function dispactThunk(thunk, f) {
+export default async function dispatchThunk(thunk, f) {
     const response = await thunk.dispatch(f);
     if (response.error) {
         return thunk.rejectWithValue({ body: null, error: response.error });

--- a/redux/utils.js
+++ b/redux/utils.js
@@ -1,7 +1,7 @@
 export default async function dispatchThunk(thunk, f) {
     const response = await thunk.dispatch(f);
     if (response.error) {
-        return thunk.rejectWithValue({ body: null, error: response.error });
+        return thunk.rejectWithValue({ body: null, error: response.payload.error });
     }
     const { payload: { body }} = response;
     return { body, error: null };

--- a/test/suite.js
+++ b/test/suite.js
@@ -5,12 +5,18 @@ import denimMiddleware from '../middleware.js';
 
 import requestReducer from '../redux/features/request.js';
 import devicesReducer, { getAllDevices, getTwin } from '../redux/features/devices.js';
+import superagent from 'superagent';
+import { Auth0SessionProvider } from '../redux/providers/auth0SessionProvider.js';
+
+require('dotenv').config();
 
 const settingsProvider = {
-    API_URL: 'https://iot-platform-db-api.azurewebsites.net'
+    API_URL: process.env.API_BASE_URL
 };
 
 const cacheProvider = {};
+
+const sessionProvider = new Auth0SessionProvider();
 
 const createStore = () =>
      configureStore({
@@ -18,10 +24,14 @@ const createStore = () =>
             requests: requestReducer,
             devices: devicesReducer
         },
-        middleware: [...denimMiddleware(settingsProvider, cacheProvider), logger]
+        middleware: [...denimMiddleware(settingsProvider, cacheProvider, sessionProvider), logger]
     });
 
 describe('Devices', () => {
+
+    before(() => {
+        return initAuth0Token(sessionProvider);
+    });
 
     it('should get all devices', async function() {
         this.enableTimeouts(false);
@@ -49,9 +59,9 @@ describe('Devices', () => {
 
     it('should return error on 404', async function() {
         const store = createStore();
-
         const response = await store.dispatch(getTwin("invalid"));
-        expect(response.payload.error).to.not.be.empty;
+
+        expect(response.payload.error).to.equal("Not Found");
         expect(response.payload.body).to.be.null;
         expect(store.getState().twin).to.be.undefined;
     });
@@ -65,12 +75,35 @@ describe('Devices', () => {
                 requests: requestReducer,
                 devices: devicesReducer
             },
-            middleware: [...denimMiddleware(invalidSettingsProvider, cacheProvider), logger]
+            middleware: [...denimMiddleware(invalidSettingsProvider, cacheProvider, sessionProvider), logger]
         });
-
         const response = await storeWithInvalidSettings.dispatch(getTwin("c5:4c:cb:2d:b0:f5"));
+
         expect(response.payload.error).to.not.be.empty;
         expect(response.payload.body).to.be.null;
         expect(storeWithInvalidSettings.getState().twin).to.be.undefined;
     });
 });
+
+const initAuth0Token = (sessionProvider) => {
+    return new Promise((resolve, reject) => {
+        superagent.agent()
+          .post(process.env.AUTH0_OAUTH_TOKEN_URL)
+          .set("Content-Type", "application/json")
+          .send({
+            client_id: process.env.AUTH0_CLIENT_ID,
+            client_secret: process.env.AUTH0_CLIENT_SECRET,
+            audience: process.env.AUTH0_AUDIENCE,
+            grant_type: "client_credentials"
+          })
+          .end(function (error, result) {
+              if (error) {
+                  reject("Error getting auth0 token")
+              } else {
+                  const auth0_token = JSON.parse(result.text).access_token;
+                  sessionProvider.setToken(auth0_token);
+                  resolve();
+              }
+          });
+    });
+}


### PR DESCRIPTION
API requests now go through the Azure api-management and need to have the bearer token. 

Added a sessionProvider to handle the token.

In the test suite, fetch a token before running the tests.
